### PR TITLE
HTTP binary client

### DIFF
--- a/examples/java-examples/src/main/java/com/edgedb/examples/Main.java
+++ b/examples/java-examples/src/main/java/com/edgedb/examples/Main.java
@@ -1,7 +1,6 @@
 package com.edgedb.examples;
 
-import com.edgedb.driver.EdgeDBClient;
-import com.edgedb.driver.EdgeDBClientConfig;
+import com.edgedb.driver.*;
 import com.edgedb.driver.exceptions.EdgeDBException;
 import com.edgedb.driver.namingstrategies.NamingStrategy;
 import org.slf4j.Logger;
@@ -24,6 +23,8 @@ public class Main {
         runJavaExamples(client);
 
         logger.info("Examples complete");
+
+        System.exit(0);
     }
 
     private static void runJavaExamples(EdgeDBClient client) {

--- a/examples/java-examples/src/main/java/com/edgedb/examples/Transactions.java
+++ b/examples/java-examples/src/main/java/com/edgedb/examples/Transactions.java
@@ -4,6 +4,7 @@ import com.edgedb.driver.EdgeDBClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
 public final class Transactions implements Example {
@@ -11,6 +12,12 @@ public final class Transactions implements Example {
 
     @Override
     public CompletionStage<Void> run(EdgeDBClient client) {
+        // verify we can run transactions
+        if(!client.supportsTransactions()) {
+            logger.info("Skipping transactions, client type {} doesn't support it", client.getClientType());
+            return CompletableFuture.completedFuture(null);
+        }
+
         return client.transaction(tx -> {
             logger.info("In transaction");
             return tx.queryRequiredSingle(String.class, "select 'Result from Transaction'");

--- a/examples/kotlin-examples/src/main/kotlin/com/edgedb/examples/Main.kt
+++ b/examples/kotlin-examples/src/main/kotlin/com/edgedb/examples/Main.kt
@@ -2,9 +2,11 @@ package com.edgedb.examples
 
 import com.edgedb.driver.EdgeDBClient
 import com.edgedb.driver.EdgeDBClientConfig
+import com.edgedb.driver.EdgeDBConnection
 import com.edgedb.driver.namingstrategies.NamingStrategy
 import kotlinx.coroutines.runBlocking
 import org.slf4j.LoggerFactory
+import kotlin.system.exitProcess
 
 object Main {
     private val logger = LoggerFactory.getLogger(Main::class.java)
@@ -37,5 +39,7 @@ object Main {
                 }
             }
         }
+
+        exitProcess(0)
     }
 }

--- a/examples/kotlin-examples/src/main/kotlin/com/edgedb/examples/Transactions.kt
+++ b/examples/kotlin-examples/src/main/kotlin/com/edgedb/examples/Transactions.kt
@@ -10,6 +10,12 @@ class Transactions : Example {
     }
 
     override suspend fun runAsync(client: EdgeDBClient) {
+        // verify we can run transactions
+        if (!client.supportsTransactions()) {
+            logger.info("Skipping transactions, client type {} doesn't support it", client.clientType)
+            return
+        }
+
         val transactionResult = client.transaction { tx ->
             tx.queryRequiredSingle(String::class.java, "SELECT 'Hello from transaction!'")
         }.await()

--- a/examples/scala-examples/build.sbt
+++ b/examples/scala-examples/build.sbt
@@ -5,7 +5,7 @@ ThisBuild / scalaVersion := "3.1.3"
 //resolvers += Resolver.file("my-test-repo", file("test"))
 
 libraryDependencies ++= Seq(
-  "com.edgedb" % "driver" % "0.0.1" from "file:///" + System.getProperty("user.dir") + "/lib/com.edgedb.driver-0.0.1-SNAPSHOT.jar",
+  "com.edgedb" % "driver" % "0.1.1" from "file:///" + System.getProperty("user.dir") + "/lib/com.edgedb.driver-0.1.1-SNAPSHOT.jar",
   "ch.qos.logback" % "logback-classic" % "1.4.7",
   "ch.qos.logback" % "logback-core" % "1.4.7",
   "com.fasterxml.jackson.core" % "jackson-databind" % "2.15.1",

--- a/examples/scala-examples/src/main/scala/Main.scala
+++ b/examples/scala-examples/src/main/scala/Main.scala
@@ -32,6 +32,8 @@ def main(): Unit = {
     Await.ready(runExample(logger, client, example), Duration.Inf)
 
   logger.info("Examples complete!")
+
+  System.exit(0)
 }
 
 private def runExample(logger: Logger, client: EdgeDBClient, example: Example)(implicit context: ExecutionContext): Future[Unit] = {

--- a/examples/scala-examples/src/main/scala/Transactions.scala
+++ b/examples/scala-examples/src/main/scala/Transactions.scala
@@ -8,6 +8,12 @@ import scala.concurrent.{ExecutionContext, Future}
 class Transactions extends Example {
   private val logger = LoggerFactory.getLogger(classOf[Transactions])
   override def run(client: EdgeDBClient)(implicit context: ExecutionContext): Future[Unit] = {
+    // verify we can run transactions
+    if (!client.supportsTransactions()) {
+      logger.info("Skipping transactions, client type {} doesn't support it", client.getClientType)
+      return Future.unit
+    }
+
     client.transaction((tx: Transaction) => {
       logger.info("In transaction")
       tx.queryRequiredSingle(classOf[String], "select 'Result from Transaction'")

--- a/src/driver/build.gradle
+++ b/src/driver/build.gradle
@@ -20,7 +20,7 @@ dependencies {
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junit_version"
     testImplementation "org.assertj:assertj-core:$assertj_version"
     testImplementation 'org.burningwave:core:12.62.6'
-    testImplementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jackson_databind_version'
+    testImplementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jackson_version"
     testImplementation "ch.qos.logback:logback-classic:$logback_version"
     testImplementation "ch.qos.logback:logback-core:$logback_version"
 }
@@ -33,12 +33,23 @@ jar {
     }
 }
 
-tasks.register('copyJarToBin') {
+def deleteOldJar = tasks.register('deleteOldJarInBin') {
+    var path = Paths.get(project.rootDir.toString(), 'examples', 'scala-examples', 'lib')
+    var paths = path.toFile().listFiles((FileFilter) { File f -> f.name.startsWith('com.edgedb.driver') })
+    delete files(paths)
+}
+
+def copyJar = tasks.register('copyJarToBin') {
     copy {
         from jar
         into Paths.get(project.rootDir.toString(), 'examples', 'scala-examples', 'lib')
     }
 }
+
+copyJar.configure {
+    dependsOn(deleteOldJar, compileJava)
+}
+
 
 publishing {
     publications {

--- a/src/driver/src/main/java/com/edgedb/driver/EdgeDBClient.java
+++ b/src/driver/src/main/java/com/edgedb/driver/EdgeDBClient.java
@@ -1,10 +1,7 @@
 package com.edgedb.driver;
 
 import com.edgedb.driver.abstractions.ClientQueryDelegate;
-import com.edgedb.driver.clients.BaseEdgeDBClient;
-import com.edgedb.driver.clients.EdgeDBTCPClient;
-import com.edgedb.driver.clients.StatefulClient;
-import com.edgedb.driver.clients.TransactableClient;
+import com.edgedb.driver.clients.*;
 import com.edgedb.driver.datatypes.Json;
 import com.edgedb.driver.exceptions.ConfigurationException;
 import com.edgedb.driver.exceptions.EdgeDBException;
@@ -80,14 +77,6 @@ public final class EdgeDBClient implements StatefulClient, EdgeDBQueryable {
         this.clientAvailability = config.getClientAvailability();
     }
 
-    private @NotNull ClientFactory createClientFactory() throws ConfigurationException {
-        if(config.getClientType() == ClientType.TCP) {
-            return EdgeDBTCPClient::new;
-        }
-
-        throw new ConfigurationException(String.format("No such implementation for client type %s found", this.config.getClientType()));
-    }
-
     /**
      * Constructs a new {@linkplain EdgeDBClient}.
      * @param connection The connection parameters used to connect this client to EdgeDB.
@@ -124,6 +113,25 @@ public final class EdgeDBClient implements StatefulClient, EdgeDBQueryable {
         this.clientFactory = other.clientFactory;
         this.session = session;
         this.clientAvailability = other.clientAvailability;
+    }
+
+    private @NotNull ClientFactory createClientFactory() throws ConfigurationException {
+        if(config.getClientType() == ClientType.TCP) {
+            return EdgeDBTCPClient::new;
+        } else if (config.getClientType() == ClientType.HTTP) {
+            return EdgeDBHttpClient::new;
+        }
+
+        throw new ConfigurationException(String.format("No such implementation for client type %s found", this.config.getClientType()));
+    }
+
+    /**
+     * Gets the underlying client type for this client pool.
+     * @return The underlying client type, usually based on transport.
+     * @see ClientType
+     */
+    public ClientType getClientType() {
+        return config.getClientType();
     }
 
     /**
@@ -232,13 +240,22 @@ public final class EdgeDBClient implements StatefulClient, EdgeDBQueryable {
         return new EdgeDBClient(this, this.session.withModule(module));
     }
 
+    // added because Map.entry cannot contain nulls
     private static final class ExecutePair<U> {
-        public final BaseEdgeDBClient client;
-        public final U result;
+        private final BaseEdgeDBClient client;
+        private final @Nullable U result;
 
-        private ExecutePair(BaseEdgeDBClient client, U result) {
+        private ExecutePair(BaseEdgeDBClient client, @Nullable U result) {
             this.client = client;
             this.result = result;
+        }
+
+        public @Nullable U getResult() {
+            return result;
+        }
+
+        public BaseEdgeDBClient getClient() {
+            return client;
         }
     }
 
@@ -254,21 +271,18 @@ public final class EdgeDBClient implements StatefulClient, EdgeDBQueryable {
                                 query,
                                 args,
                                 capabilities
-                        ).handle((r, x) -> new ExecutePair<>(client, r))
+                        ).thenApply(r -> new ExecutePair<>(client, r))
                 )
-                .handle((pair, exc) -> {
-                    try {
-                        pair.client.close();
-                    } catch (Exception e) {
-                        throw new CompletionException(e);
+                .whenComplete((entry, exc) -> {
+                    if(entry != null) {
+                        try {
+                            entry.getClient().close();
+                        } catch (Exception e) {
+                            throw new CompletionException(e);
+                        }
                     }
-
-                    if(exc != null) {
-                        throw new CompletionException(exc);
-                    }
-
-                    return pair.result;
-                });
+                })
+                .thenApply(ExecutePair::getResult);
     }
 
     @Override
@@ -374,7 +388,12 @@ public final class EdgeDBClient implements StatefulClient, EdgeDBQueryable {
         return this.poolHolder.acquireContract()
                 .thenApply(contract -> {
                     logger.trace("Contract acquired, remaining handles: {}", this.poolHolder.remaining());
-                    var client = clientFactory.create(this.connection, this.config, contract);
+                    BaseEdgeDBClient client;
+                    try {
+                        client = clientFactory.create(this.connection, this.config, contract);
+                    } catch (EdgeDBException e) {
+                        throw new CompletionException(e);
+                    }
                     contract.register(client, this::acceptClient);
                     client.onReady(this::onClientReady);
                     logger.debug("client instance created: {}", client);
@@ -385,6 +404,7 @@ public final class EdgeDBClient implements StatefulClient, EdgeDBQueryable {
 
     @FunctionalInterface
     private interface ClientFactory {
-        BaseEdgeDBClient create(EdgeDBConnection connection, EdgeDBClientConfig config, AutoCloseable poolHandle);
+        BaseEdgeDBClient create(EdgeDBConnection connection, EdgeDBClientConfig config, AutoCloseable poolHandle)
+                throws EdgeDBException;
     }
 }

--- a/src/driver/src/main/java/com/edgedb/driver/EdgeDBConnection.java
+++ b/src/driver/src/main/java/com/edgedb/driver/EdgeDBConnection.java
@@ -146,7 +146,7 @@ public class EdgeDBConnection implements Cloneable {
      * @return The hostname part of the connection.
      */
     public @NotNull String getHostname() {
-        return hostname == null ? "127.0.0.1" : hostname;
+        return hostname == null ? "localhost" : hostname;
     }
 
     /**

--- a/src/driver/src/main/java/com/edgedb/driver/binary/PacketReader.java
+++ b/src/driver/src/main/java/com/edgedb/driver/binary/PacketReader.java
@@ -61,6 +61,21 @@ public class PacketReader {
         this.buffer.skipBytes(count);
     }
 
+    public void skip(long count) {
+        if(count >> 32 == 0) {
+            // can convert to int
+            skip((int)count);
+            return;
+        }
+
+        var temp = count;
+        do {
+            this.buffer.skipBytes((int) temp);
+            temp -= Integer.MAX_VALUE;
+        }
+        while (temp >= Integer.MAX_VALUE);
+    }
+
     public boolean isEmpty() {
         return this.buffer.readableBytes() == 0;
     }

--- a/src/driver/src/main/java/com/edgedb/driver/binary/duplexers/HttpDuplexer.java
+++ b/src/driver/src/main/java/com/edgedb/driver/binary/duplexers/HttpDuplexer.java
@@ -1,30 +1,50 @@
 package com.edgedb.driver.binary.duplexers;
 
+import com.edgedb.driver.binary.PacketSerializer;
 import com.edgedb.driver.binary.packets.receivable.Receivable;
 import com.edgedb.driver.binary.packets.sendables.Sendable;
-import com.edgedb.driver.clients.EdgeDBBinaryClient;
 import com.edgedb.driver.clients.EdgeDBHttpClient;
+import com.edgedb.driver.exceptions.ConnectionFailedException;
 import com.edgedb.driver.exceptions.EdgeDBException;
+import io.netty.buffer.ByteBufInputStream;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import javax.naming.OperationNotSupportedException;
+import java.net.http.HttpRequest;
+import java.util.ArrayDeque;
+import java.util.Objects;
+import java.util.Queue;
 import java.util.concurrent.*;
 
+import static com.edgedb.driver.util.ComposableUtil.composeWith;
+
 public class HttpDuplexer extends Duplexer {
+    private static final Logger logger = LoggerFactory.getLogger(HttpDuplexer.class);
     private static final String HTTP_BINARY_CONTENT_TYPE = "application/x.edgedb.v_1_0.binary";
 
     private final EdgeDBHttpClient client;
     private final Semaphore lock;
     private final Executor lockExecutor;
+    private final Queue<@NotNull Receivable> packetQueue;
+    private final Queue<CompletableFuture<Receivable>> readPromises;
+
     public HttpDuplexer(EdgeDBHttpClient client) {
         this.client = client;
         this.lock = new Semaphore(1);
         this.lockExecutor = Executors.newSingleThreadExecutor();
+        this.packetQueue = new ArrayDeque<>();
+        this.readPromises = new ArrayDeque<>();
     }
 
     @Override
     public void reset() {
+        packetQueue.clear();
+        readPromises.clear();
 
+        client.clearToken();
     }
 
     @Override
@@ -39,43 +59,129 @@ public class HttpDuplexer extends Duplexer {
 
     @Override
     public CompletionStage<Receivable> readNext() {
-        return acquireLock()
+        return acquireLock("READ")
                 .thenCompose((v) -> readNext0())
-                .whenCompleteAsync((v,e) -> lock.release(), lockExecutor);
+                .whenCompleteAsync((v,e) -> {
+                    logger.debug("[READ]: Releasing lock");
+                    lock.release();
+                }, lockExecutor);
     }
 
     private CompletionStage<Receivable> readNext0() {
+        logger.debug("Preforming read, is authed?: {}", isConnected());
         if(!isConnected()) {
             return CompletableFuture.failedFuture(
                     new EdgeDBException("Cannot preform read without authorization")
             );
+        }
 
-
+        logger.debug("Packet queue empty?: {}", packetQueue.isEmpty());
+        if(packetQueue.isEmpty()) {
+            var promise = new CompletableFuture<Receivable>();
+            logger.debug("Enqueueing read promise {}...", promise.hashCode());
+            readPromises.offer(promise);
+            promise.whenComplete((v,e) -> {
+                logger.debug("Read promise {} complete", promise.hashCode());
+            });
+            return promise;
+        } else {
+            logger.debug("Completing from polled packet");
+            return CompletableFuture.completedFuture(packetQueue.poll());
         }
     }
 
     @Override
     public CompletionStage<Void> send(Sendable packet, @Nullable Sendable... packets) {
-        return acquireLock()
-                .thenCompose((v) -> send0(packet, packets));
+        return acquireLock("WRITE")
+                .thenCompose((v) -> send0(packet, packets))
+                .whenCompleteAsync((v,e) -> {
+                    logger.debug("[WRITE]: Releasing lock");
+                    lock.release();
+                }, lockExecutor);
     }
 
     private CompletionStage<Void> send0(Sendable packet, @Nullable Sendable... packets) {
-
+        return verifyAuthenticated()
+                .thenApply((v) -> {
+                    try {
+                        logger.debug("Creating buffer stream");
+                        return new ByteBufInputStream(PacketSerializer.serialize(packet, packets), true);
+                    } catch (OperationNotSupportedException e) {
+                        logger.debug("Failed to create buffer stream", e);
+                        throw new CompletionException(e);
+                    }
+                })
+                .thenApply(stream ->
+                    HttpRequest.newBuilder()
+                            .uri(client.getExecUri())
+                            .header("Authorization", "Bearer " + client.getToken())
+                            .header("Content-Type", HTTP_BINARY_CONTENT_TYPE)
+                            .header("X-EdgeDB-User", client.getConnectionArguments().getUsername())
+                            .POST(HttpRequest.BodyPublishers.ofInputStream(() -> stream))
+                            .build()
+                )
+                .thenCompose((request) -> {
+                    logger.debug("Sending execution request...");
+                    return client.httpClient.sendAsync(request, PacketSerializer.PACKET_BODY_HANDLER);
+                })
+                .thenCompose(EdgeDBHttpClient::ensureSuccess)
+                .thenAccept(response -> {
+                    logger.debug("Enqueueing {} packets", response.body().size());
+                    for(var receivable : response.body()) {
+                        packetQueue.offer(receivable);
+                    }
+                })
+                .thenCompose((v) -> processReadPromises());
     }
 
-    private CompletionStage<Void> acquireLock() {
+    private CompletionStage<Void> processReadPromises() {
+        logger.debug(
+                "Processing read promises. has promises?: {}, has data?: {}",
+                !readPromises.isEmpty(), !packetQueue.isEmpty()
+        );
+
+        if(!readPromises.isEmpty() && !packetQueue.isEmpty()) {
+            var promise = readPromises.poll();
+            var receivable = Objects.requireNonNull(packetQueue.poll()); // closed by the 'composeWith' func
+
+            logger.debug("Executing promise {} with {}", promise.hashCode(), receivable.getMessageType());
+
+            return composeWith(receivable, (v) -> promise.completeAsync(() -> v))
+                    .thenCompose((v) -> processReadPromises());
+        }
+
+        logger.debug("Completed read promise steps");
+        return CompletableFuture.completedFuture(null);
+    }
+
+    private CompletionStage<Void> verifyAuthenticated() {
+        return CompletableFuture
+                .runAsync(() -> {
+                    logger.debug("Verifying authentication state... is authed?: {}", isConnected());
+                    if(!isConnected()) {
+                        throw new CompletionException(
+                                new ConnectionFailedException("Cannot send to an unauthorized connection")
+                        );
+                    }
+                });
+    }
+
+    private CompletionStage<Void> acquireLock(String operation) {
         return CompletableFuture
                 .runAsync(() -> {
                     try {
+                        logger.debug("[{}]: Acquiring lock...", operation);
                         if(!lock.tryAcquire(
                                 client.getConfig().getMessageTimeoutValue(),
                                 client.getConfig().getMessageTimeoutUnit())
                         ) {
+                            logger.debug("[{}]: Lock timed out", operation);
                             throw new CompletionException(
                                     new TimeoutException("A message read process passed the configured message timeout")
                             );
                         }
+
+                        logger.debug("[{}]: Lock acquired", operation);
                     } catch (InterruptedException v) {
                         throw new CompletionException(v);
                     }
@@ -85,6 +191,40 @@ public class HttpDuplexer extends Duplexer {
 
     @Override
     public CompletionStage<Void> duplex(DuplexCallback func, @NotNull Sendable packet, @Nullable Sendable... packets) {
-        return null;
+        return acquireLock("DUPLEX")
+                .thenCompose((v) -> duplex0(func, packet, packets))
+                .whenCompleteAsync((v,e) -> {
+                    logger.debug("[DUPLEX]: Releasing lock");
+                    lock.release();
+                }, lockExecutor);
+    }
+
+    private CompletionStage<Void> duplex0(DuplexCallback func, @NotNull Sendable packet, @Nullable Sendable... packets) {
+        var duplexPromise = new CompletableFuture<Void>();
+        return send0(packet, packets)
+                .thenCompose((v) -> processDuplexStep(func, duplexPromise));
+    }
+
+    private CompletionStage<Void> processDuplexStep(DuplexCallback func, CompletableFuture<Void> promise) {
+        return readNext0()
+                .thenApply((packet) -> new DuplexResult(packet, promise))
+                .thenCompose((state) -> {
+                    try {
+                        return func.process(state);
+                    } catch (EdgeDBException | OperationNotSupportedException e) {
+                        return CompletableFuture.failedFuture(e);
+                    }
+                })
+                .thenCompose((v) -> {
+                    if(promise.isDone()) {
+                        if(promise.isCompletedExceptionally() || promise.isCancelled()) {
+                            return promise;
+                        }
+
+                        return CompletableFuture.completedFuture(null);
+                    }
+
+                    return processDuplexStep(func, promise);
+                });
     }
 }

--- a/src/driver/src/main/java/com/edgedb/driver/binary/duplexers/HttpDuplexer.java
+++ b/src/driver/src/main/java/com/edgedb/driver/binary/duplexers/HttpDuplexer.java
@@ -1,0 +1,75 @@
+package com.edgedb.driver.binary.duplexers;
+
+import com.edgedb.driver.binary.packets.receivable.Receivable;
+import com.edgedb.driver.binary.packets.sendables.Sendable;
+import com.edgedb.driver.clients.EdgeDBBinaryClient;
+import com.edgedb.driver.clients.EdgeDBHttpClient;
+import com.edgedb.driver.exceptions.EdgeDBException;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.concurrent.*;
+
+public class HttpDuplexer extends Duplexer {
+    private static final String HTTP_BINARY_CONTENT_TYPE = "application/x.edgedb.v_1_0.binary";
+
+    private final EdgeDBHttpClient client;
+    private final Semaphore lock;
+    private final Executor lockExecutor;
+    public HttpDuplexer(EdgeDBHttpClient client) {
+        this.client = client;
+        this.lock = new Semaphore(1);
+        this.lockExecutor = Executors.newSingleThreadExecutor();
+    }
+
+    @Override
+    public void reset() {
+
+    }
+
+    @Override
+    public boolean isConnected() {
+        return client.getToken() != null;
+    }
+
+    @Override
+    public CompletionStage<Void> disconnect() {
+        return CompletableFuture.runAsync(client::clearToken);
+    }
+
+    @Override
+    public CompletionStage<Receivable> readNext() {
+        return CompletableFuture
+                .supplyAsync(() -> {
+                    try {
+                        lock.tryAcquire(client.getConfig().getMessageTimeoutValue(), client.getConfig().getMessageTimeoutUnit())
+                    } catch (InterruptedException v) {
+                        throw new CompletionException(v);
+                    }
+
+                    return (Void)null;
+                }, lockExecutor)
+                .thenCompose((v) -> readNext0())
+                .whenCompleteAsync((v,e) -> lock.release(), lockExecutor);
+    }
+
+    private CompletionStage<Receivable> readNext0() {
+        if(!isConnected()) {
+            return CompletableFuture.failedFuture(
+                    new EdgeDBException("Cannot preform read without authorization")
+            );
+
+
+        }
+    }
+
+    @Override
+    public CompletionStage<Void> send(Sendable packet, @Nullable Sendable... packets) {
+        return null;
+    }
+
+    @Override
+    public CompletionStage<Void> duplex(DuplexCallback func, @NotNull Sendable packet, @Nullable Sendable... packets) {
+        return null;
+    }
+}

--- a/src/driver/src/main/java/com/edgedb/driver/binary/packets/ServerMessageType.java
+++ b/src/driver/src/main/java/com/edgedb/driver/binary/packets/ServerMessageType.java
@@ -1,9 +1,8 @@
 package com.edgedb.driver.binary.packets;
 
-import java.util.HashMap;
-import java.util.Map;
+import com.edgedb.driver.binary.BinaryEnum;
 
-public enum ServerMessageType {
+public enum ServerMessageType implements BinaryEnum<Byte> {
     AUTHENTICATION (0x52),
     COMMAND_COMPLETE (0x43),
     COMMAND_DATA_DESCRIPTION (0x54),
@@ -20,23 +19,13 @@ public enum ServerMessageType {
     SERVER_KEY_DATA (0x4b);
 
     private final byte code;
-    private final static Map<Byte, ServerMessageType> map = new HashMap<>();
 
     ServerMessageType(int code) {
         this.code = (byte)code;
     }
 
-    static {
-        for (ServerMessageType v : ServerMessageType.values()) {
-            map.put(v.code, v);
-        }
-    }
-
-    public static ServerMessageType valueOf(Byte raw) {
-        return map.get(raw);
-    }
-
-    public byte getCode() {
+    @Override
+    public Byte getValue() {
         return code;
     }
 }

--- a/src/driver/src/main/java/com/edgedb/driver/binary/packets/receivable/Receivable.java
+++ b/src/driver/src/main/java/com/edgedb/driver/binary/packets/receivable/Receivable.java
@@ -2,8 +2,12 @@ package com.edgedb.driver.binary.packets.receivable;
 
 import com.edgedb.driver.binary.packets.ServerMessageType;
 import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public interface Receivable extends AutoCloseable {
+    Logger logger = LoggerFactory.getLogger(Receivable.class);
+
     ServerMessageType getMessageType();
 
     @SuppressWarnings("unchecked")
@@ -18,5 +22,7 @@ public interface Receivable extends AutoCloseable {
     }
 
     @Override
-    default void close() throws Exception {}
+    default void close() throws Exception {
+        logger.debug("Closed {}:{}", this.hashCode(), getMessageType());
+    }
 }

--- a/src/driver/src/main/java/com/edgedb/driver/clients/EdgeDBHttpClient.java
+++ b/src/driver/src/main/java/com/edgedb/driver/clients/EdgeDBHttpClient.java
@@ -1,0 +1,192 @@
+package com.edgedb.driver.clients;
+
+import com.edgedb.driver.EdgeDBClientConfig;
+import com.edgedb.driver.EdgeDBConnection;
+import com.edgedb.driver.TransactionState;
+import com.edgedb.driver.binary.duplexers.Duplexer;
+import com.edgedb.driver.binary.duplexers.HttpDuplexer;
+import com.edgedb.driver.exceptions.ConnectionFailedException;
+import com.edgedb.driver.exceptions.ScramException;
+import com.edgedb.driver.util.Scram;
+import org.jetbrains.annotations.Nullable;
+
+import java.net.ProtocolException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.stream.Collectors;
+
+public final class EdgeDBHttpClient extends EdgeDBBinaryClient {
+    private static final String HTTP_TOKEN_AUTH_METHOD = "SCRAM-SHA-256";
+    private final HttpDuplexer duplexer;
+    private final HttpClient client;
+
+    private @Nullable String authToken;
+    private @Nullable URI baseUri;
+    private @Nullable URI authUri;
+
+    public EdgeDBHttpClient(EdgeDBConnection connection, EdgeDBClientConfig config, AutoCloseable poolHandle) {
+        super(connection, config, poolHandle);
+        this.duplexer = new HttpDuplexer(this);
+        this.client = HttpClient.newHttpClient();
+    }
+
+    public String getToken() {
+        return this.authToken;
+    }
+
+    public void clearToken() {
+        this.authToken = null;
+    }
+
+    private CompletionStage<String> authenticate() {
+        return CompletableFuture
+                .supplyAsync(() -> {
+                    var scram = new Scram();
+
+                    var first = scram.buildInitialMessage(getConnectionArguments().getUsername());
+
+                    var request = HttpRequest.newBuilder()
+                            .uri(getAuthUri())
+                            .version(HttpClient.Version.HTTP_2)
+                            .header(
+                                    "Authorization",
+                                    HTTP_TOKEN_AUTH_METHOD
+                                            + " data="
+                                            + Base64.getEncoder().encodeToString(first.getBytes(StandardCharsets.UTF_8)))
+                            .GET()
+                            .timeout(Duration.of(
+                                    getConfig().getMessageTimeoutValue(),
+                                    getConfig().getMessageTimeoutUnit().toChronoUnit()))
+                            .build();
+
+                    return Map.entry(scram, request);
+                })
+                .thenCompose(entry ->
+                        client.sendAsync(entry.getValue(), HttpResponse.BodyHandlers.ofByteArray())
+                                .thenApply(response -> Map.entry(entry.getKey(), response))
+                )
+                .thenCompose(EdgeDBHttpClient::ensureSuccess)
+                .thenCompose(entry -> {
+                    var authenticate = entry.getValue().headers().firstValue("www-authenticate");
+
+                    if(authenticate.isEmpty()) {
+                        return CompletableFuture.failedFuture(
+                                new ProtocolException("The only supported auth method is " + HTTP_TOKEN_AUTH_METHOD)
+                        );
+                    }
+
+                    var authenticateData = authenticate.get().substring(HTTP_TOKEN_AUTH_METHOD.length() + 1);
+
+                    var keys = parseKeys(authenticateData);
+
+                    Scram.SASLFinalMessage finalMsg;
+
+                    try {
+                        finalMsg = entry.getKey().buildFinalMessage(
+                                new String(Base64.getDecoder().decode(keys.get("data")), StandardCharsets.UTF_8),
+                                getConnectionArguments().getPassword()
+                        );
+                    } catch (ScramException e) {
+                        return CompletableFuture.failedFuture(e);
+                    }
+
+                    String payload = "sid=" +
+                            keys.get("sid") +
+                            " data=" +
+                            Base64.getEncoder().encodeToString(finalMsg.message.getBytes(StandardCharsets.UTF_8));
+
+                    var request = HttpRequest.newBuilder()
+                            .uri(getAuthUri())
+                            .header(
+                                    "Authorization",
+                                    HTTP_TOKEN_AUTH_METHOD + " " + payload
+                            )
+                            .GET()
+                            .build();
+
+                    return client.sendAsync(request, HttpResponse.BodyHandlers.ofString());
+                })
+                .thenCompose(EdgeDBHttpClient::ensureSuccess)
+                .thenApply(HttpResponse::body);
+    }
+
+    private static <T> CompletionStage<HttpResponse<T>> ensureSuccess(HttpResponse<T> response) {
+        if(response.statusCode() / 100 != 2) {
+            return CompletableFuture.failedFuture(
+                    new ConnectionFailedException(
+                            "Could not authenticate: " + response.statusCode()
+                    )
+            );
+        }
+
+        return CompletableFuture.completedFuture(response);
+    }
+
+    private static <T, U> CompletionStage<Map.Entry<T, HttpResponse<U>>> ensureSuccess(
+            Map.Entry<T, HttpResponse<U>> entry
+    ) {
+        return ensureSuccess(entry.getValue())
+                .thenApply(v -> entry);
+    }
+
+    private Map<String, String> parseKeys(String s) {
+        return Arrays.stream(s.split(","))
+                .map(v -> v.split("="))
+                .collect(Collectors.toMap(
+                        v -> v[0].trim(),
+                        v -> v[1]
+                ));
+    }
+
+    private synchronized URI getAuthUri() {
+        if(authUri != null) {
+            return authUri;
+        }
+
+        return authUri = getBaseUri().resolve("/auth/token");
+    }
+
+    private synchronized URI getBaseUri() {
+        if(authUri != null) {
+            return authUri;
+        }
+
+        return authUri = URI.create(
+                "https://" + getConnectionArguments().getHostname() + ":" + getConnectionArguments().getPort()
+        );
+    }
+
+    @Override
+    protected Duplexer getDuplexer() {
+        return this.duplexer;
+    }
+
+    @Override
+    protected void setTransactionState(TransactionState state) {
+        // invalid for this client
+    }
+
+    @Override
+    protected CompletionStage<Void> openConnection() {
+        if(authToken == null) {
+            return authenticate()
+                    .thenAccept(token -> this.authToken = token);
+        }
+
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    protected CompletionStage<Void> closeConnection() {
+        return CompletableFuture.completedFuture(null);
+    }
+}

--- a/src/driver/src/main/java/com/edgedb/driver/clients/EdgeDBTCPClient.java
+++ b/src/driver/src/main/java/com/edgedb/driver/clients/EdgeDBTCPClient.java
@@ -42,7 +42,6 @@ public class EdgeDBTCPClient extends EdgeDBBinaryClient implements TransactableC
     public EdgeDBTCPClient(EdgeDBConnection connection, EdgeDBClientConfig config, AutoCloseable poolHandle) {
         super(connection, config, poolHandle);
         this.duplexer = new ChannelDuplexer(this);
-        setDuplexer(this.duplexer);
 
         this.bootstrap = new Bootstrap()
                 .option(ChannelOption.ALLOCATOR, PooledByteBufAllocator.DEFAULT)
@@ -79,6 +78,12 @@ public class EdgeDBTCPClient extends EdgeDBBinaryClient implements TransactableC
                     }
                 });
     }
+
+    @Override
+    protected @NotNull ChannelDuplexer getDuplexer() {
+        return this.duplexer;
+    }
+
     @Override
     protected void setTransactionState(TransactionState state) {
         this.transactionState = state;

--- a/src/driver/src/main/java/com/edgedb/driver/util/SslUtils.java
+++ b/src/driver/src/main/java/com/edgedb/driver/util/SslUtils.java
@@ -5,40 +5,52 @@ import com.edgedb.driver.TLSSecurityMode;
 import io.netty.handler.ssl.SslContextBuilder;
 import org.jetbrains.annotations.NotNull;
 
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
 import javax.net.ssl.X509TrustManager;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.security.GeneralSecurityException;
-import java.security.KeyStore;
-import java.security.KeyStoreException;
-import java.security.NoSuchAlgorithmException;
+import java.security.*;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 
 public class SslUtils {
+    public static final X509TrustManager INSECURE_TRUST_MANAGER = new X509TrustManager() {
+        public java.security.cert.X509Certificate[] getAcceptedIssuers() {
+            return new X509Certificate[0];
+        }
+        public void checkClientTrusted(
+                java.security.cert.X509Certificate[] certs, String authType) {
+        }
+        public void checkServerTrusted(
+                java.security.cert.X509Certificate[] certs, String authType) {
+        }
+    };
+
+    public static void initContextWithConnectionDetails(
+            @NotNull SSLContext context, @NotNull EdgeDBConnection connection)
+    throws KeyManagementException, CertificateException, NoSuchAlgorithmException, KeyStoreException, IOException {
+        if(connection.getTLSSecurity() == TLSSecurityMode.INSECURE) {
+            context.init(null, new TrustManager[] {INSECURE_TRUST_MANAGER}, null);
+            return;
+        }
+
+        context.init(null, getTrustManagerFactory(connection).getTrustManagers(), null);
+    }
+
     public static void applyTrustManager(@NotNull EdgeDBConnection connection, @NotNull SslContextBuilder builder) throws GeneralSecurityException, IOException {
         if(connection.getTLSSecurity() == TLSSecurityMode.INSECURE) {
-            builder.trustManager(new X509TrustManager() {
-                public java.security.cert.X509Certificate[] getAcceptedIssuers() {
-                    return new X509Certificate[0];
-                }
-                public void checkClientTrusted(
-                        java.security.cert.X509Certificate[] certs, String authType) {
-                }
-                public void checkServerTrusted(
-                        java.security.cert.X509Certificate[] certs, String authType) {
-                }
-            });
+            builder.trustManager(INSECURE_TRUST_MANAGER);
         }
         else {
             builder.trustManager(getTrustManagerFactory(connection));
         }
     }
 
-    private static @NotNull TrustManagerFactory getTrustManagerFactory(@NotNull EdgeDBConnection connection) throws NoSuchAlgorithmException, KeyStoreException, CertificateException, IOException {
+    public static @NotNull TrustManagerFactory getTrustManagerFactory(@NotNull EdgeDBConnection connection) throws NoSuchAlgorithmException, KeyStoreException, CertificateException, IOException {
         var authority = connection.getTLSCertificateAuthority();
 
         TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());

--- a/src/driver/src/main/java/module-info.java
+++ b/src/driver/src/main/java/module-info.java
@@ -18,6 +18,7 @@ module com.edgedb.driver {
     requires io.netty.handler;
     requires org.jooq.joou;
     requires org.reflections;
+    requires java.net.http;
 
     opens com.edgedb.driver;
 }


### PR DESCRIPTION
This PR implements an HTTP binary client

#### API surface changes
- Configuration for client type now accepts `HTTP`:
  ```java
  var client = new EdgeDBClient(EdgeDBClientConfig.builder()
      .withClientType(ClientType.HTTP)
      .build()
  )
  ```
- Added `getClientType` method to `EdgeDBClient`
  ```java
  /**
   * Gets the underlying client type for this client pool.
   * @return The underlying client type, usually based on transport.
   * @see ClientType
   */
  public ClientType getClientType() {
      return config.getClientType();
  }
  ```

#### Fixes
- Fixed an issue where an exception during pooled execution isn't propagated to the callee correctly.
- Fixed an issue during parsing where `ReadyForCommand` wouldn't be consumed in the failed parse case.

#### Overview
A new duplexer called [`HttpDuplexer`](https://github.com/edgedb/edgedb-java/blob/feat/http-binary-client/src/driver/src/main/java/com/edgedb/driver/binary/duplexers/HttpDuplexer.java) was introduced which provides the duplex implementation for HTTP via a promise queue. On top of this, a new client class, [`EdgeDBHttpClient`](https://github.com/edgedb/edgedb-java/blob/feat/http-binary-client/src/driver/src/main/java/com/edgedb/driver/clients/EdgeDBHttpClient.java), was added which extends the `EdgeDBBinary` client to support the binary protocol over HTTP by proxying the duplexer to the protocol code.

One implementation note: Java being java doesn't auto implement DNS name resolving for matching URI hosts to the certificates (see [this stack overflow post which is related](https://stackoverflow.com/questions/6793174/third-party-signed-ssl-certificate-for-localhost-or-127-0-0-1)) so using `127.0.0.1` as a hostname for HTTP clients will not work. To fix this, the default `hostname` in `EdgeDBConnection` was changed from `127.0.0.1` to `localhost` to match certificates, this should not effect other behavior of the client.

