### PR TITLE
Fix retry connection on send 

### DIFF
--- a/src/driver/src/main/java/com/edgedb/driver/binary/duplexers/ChannelDuplexer.java
+++ b/src/driver/src/main/java/com/edgedb/driver/binary/duplexers/ChannelDuplexer.java
@@ -223,7 +223,7 @@ public class ChannelDuplexer extends Duplexer {
         });
     }
 
-    public CompletionStage<Void> send0(AtomicInteger attempts, Sendable packet, @Nullable Sendable... packets) {
+    private CompletionStage<Void> send0(AtomicInteger attempts, Sendable packet, @Nullable Sendable... packets) {
         return exceptionallyCompose(send1(packet, packets), e -> {
             logger.debug("Caught failed send attempt");
 

--- a/src/driver/src/main/java/com/edgedb/driver/clients/EdgeDBBinaryClient.java
+++ b/src/driver/src/main/java/com/edgedb/driver/clients/EdgeDBBinaryClient.java
@@ -940,7 +940,7 @@ public abstract class EdgeDBBinaryClient extends BaseEdgeDBClient {
     private CompletionStage<Void> retryableConnect() {
         try {
             return exceptionallyCompose(this.openConnection(), err -> {
-                if(err.getCause() instanceof ConnectionFailedTemporarilyException) {
+                if(err instanceof EdgeDBException && ((EdgeDBException)err).shouldReconnect) {
                     if(getConfig().getConnectionRetryMode() == ConnectionRetryMode.NEVER_RETRY) {
                         return CompletableFuture.failedFuture(new ConnectionFailedException(err));
                     }

--- a/src/driver/src/main/java/com/edgedb/driver/exceptions/ConnectionFailedTemporarilyException.java
+++ b/src/driver/src/main/java/com/edgedb/driver/exceptions/ConnectionFailedTemporarilyException.java
@@ -12,4 +12,12 @@ public class ConnectionFailedTemporarilyException extends EdgeDBException {
     public ConnectionFailedTemporarilyException(Throwable err) {
         super("The connection could not be established at this time", err, true, true);
     }
+
+    /**
+     * Constructs a new {@linkplain ConnectionFailedTemporarilyException}.
+     * @param message A detailed message describing why this exception was raised.
+     */
+    public ConnectionFailedTemporarilyException(String message) {
+        super(message);
+    }
 }


### PR DESCRIPTION
## Summary
The binding would attempt to reconnect in the `send` method if the connection wasn't established:
https://github.com/edgedb/edgedb-java/blob/46c513285faffee9992e47447eb542f5c7a158ae/src/driver/src/main/java/com/edgedb/driver/binary/duplexers/ChannelDuplexer.java#L200-L213
The issue with this is that the `connect` method on the `EdgeDBBinaryClient` would be recursively called if the underlying connection was closed during the send function:
```
EdgeDBBinaryClient#connect()
├─ EdgeDBBinaryClient#connectInternal()
│  └─ EdgeDBBinaryClient#retryableConnect()
│     └─ ChannelDuplexer#send()
│        ├─ IsConnected?
└────────╬━┸- Channel#write()
         └─ EdgeDBBinaryClient#reconnect()
            └─ EdgeDBBinaryClient#connect()
              └─ duplicate frames hidden...
```

The way the attempts were calculated here are locals to only the method, they're not passed down the call hierarchy so this bug would occur.

### Changes
The send method will now recall itself only when an `EdgeDBException` is thrown with the `ShouldRetry` flag. Any other exceptions are propagated to the caller which is responsible for handling them.

 