### PR TITLE
Fix data issues when spanning >16k bytes

### DIFF
--- a/dbschema/migrations/00007.edgeql
+++ b/dbschema/migrations/00007.edgeql
@@ -1,0 +1,10 @@
+CREATE MIGRATION m1tig3qk3mnrb2xpszwyodgurkdeyza6yt67zo7kfljc2icy3e7yma
+    ONTO m1vxu37wczr357ppyrbhfon2msem5oczk7mjszhx2xzp2qlxpazana
+{
+  CREATE MODULE tests IF NOT EXISTS;
+  CREATE TYPE tests::TestDatastructure {
+      CREATE REQUIRED PROPERTY a: std::str;
+      CREATE REQUIRED PROPERTY b: std::str;
+      CREATE REQUIRED PROPERTY c: std::str;
+  };
+};

--- a/dbschema/tests.esdl
+++ b/dbschema/tests.esdl
@@ -1,0 +1,7 @@
+module tests {
+    type TestDatastructure {
+        required property a -> str;
+        required property b -> str;
+        required property c -> str;
+    }
+}

--- a/examples/java-examples/src/main/java/com/edgedb/examples/GlobalsAndConfig.java
+++ b/examples/java-examples/src/main/java/com/edgedb/examples/GlobalsAndConfig.java
@@ -10,7 +10,7 @@ import java.util.UUID;
 import java.util.concurrent.CompletionStage;
 
 public final class GlobalsAndConfig implements Example {
-    private static final Logger logger = LoggerFactory.getLogger(AbstractTypes.class);
+    private static final Logger logger = LoggerFactory.getLogger(GlobalsAndConfig.class);
 
     @Override
     public CompletionStage<Void> run(EdgeDBClient client) {

--- a/src/driver/src/test/java/ProtocolTests.java
+++ b/src/driver/src/test/java/ProtocolTests.java
@@ -1,0 +1,103 @@
+import com.edgedb.driver.EdgeDBClient;
+import com.edgedb.driver.annotations.EdgeDBType;
+import com.edgedb.driver.exceptions.EdgeDBException;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.*;
+import java.util.concurrent.ExecutionException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ProtocolTests {
+    private static final Logger logger = LoggerFactory.getLogger(ProtocolTests.class);
+
+    @EdgeDBType
+    public static class TestDatastructure {
+        public UUID id;
+
+        public String a;
+
+        public String b;
+
+        public String c;
+    }
+
+    /**
+     * The goal is to test the contract logic in {@linkplain com.edgedb.driver.binary.PacketSerializer}, specifically
+     * the decoder returned from the <b>createDecoder</b> function. To achieve this, we can query something that
+     * returns either multiple data packets amounting up to >16k bytes, or a single data packet that is >16k bytes.
+     */
+    @Test
+    public void testPacketContract() throws EdgeDBException, IOException, ExecutionException, InterruptedException {
+        var client = new EdgeDBClient().withModule("tests");
+
+        // insert 1k items
+        logger.info("Removing old data structures...");
+        client.execute("DELETE TestDatastructure")
+                .toCompletableFuture().get();
+
+        var results = new HashMap<UUID, String[]>();
+
+        logger.info("Inserting 1000 items...");
+
+        for(int i = 0; i != 1000; i++){
+            var data = new String[] {
+                    generateRandomString(),
+                    generateRandomString(),
+                    generateRandomString()
+            };
+
+            var result = client.queryRequiredSingle(TestDatastructure.class, "INSERT TestDatastructure { a := <str>$a, b := <str>$b, c := <str>$c }", new HashMap<>(){{
+                put("a", data[0]);
+                put("b", data[1]);
+                put("c", data[2]);
+            }}).toCompletableFuture().get();
+
+            results.put(result.id, data);
+        }
+
+        logger.info("Querying all items...");
+
+        // assert the data can be read via binary and json
+        var structures = client.query(TestDatastructure.class, "SELECT TestDatastructure { id, a, b, c }")
+                .toCompletableFuture().get();
+
+        var json = client.queryJson("SELECT TestDatastructure { id, a, b, c }")
+                .toCompletableFuture().get();
+
+        var structuresFromJson = List.of(new JsonMapper().readValue(json.getValue(), TestDatastructure[].class));
+
+        assertStructuresMatch(structures, results);
+        assertStructuresMatch(structuresFromJson, results);
+    }
+
+    private void assertStructuresMatch(List<TestDatastructure> source, Map<UUID, String[]> truth) {
+        for(var structure : source) {
+            assert structure != null;
+
+            var expected = truth.get(structure.id);
+
+            assertThat(structure.a).isEqualTo(expected[0]);
+            assertThat(structure.b).isEqualTo(expected[1]);
+            assertThat(structure.c).isEqualTo(expected[2]);
+
+            logger.info("{} passed [a: {}, b: {}, c: {}]", structure.id, structure.a, structure.b, structure.c);
+        }
+    }
+
+    private static String generateRandomString() {
+        final var chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890";
+
+        Random rand =new Random();
+        StringBuilder res=new StringBuilder();
+        for (int i = 0; i < 17; i++) {
+            int randIndex=rand.nextInt(chars.length());
+            res.append(chars.charAt(randIndex));
+        }
+        return res.toString();
+    }
+}


### PR DESCRIPTION
## Summary
Netty transfers data to the binding in chunks of <=16k bytes at a time, the EdgeDB protocol can have messages with lengths over that size, therefor the binding must collect the chunks to build a complete message if the protocol message is >16k bytes.

The binding did *attempt* to do this with a contract structure, creating `PacketContract`s for messages that can't be read with the provided buffer, ref:

https://github.com/edgedb/edgedb-java/blob/abb7f8a797e0d2ec21c0ee4ba298022fa2cf06a9/src/driver/src/main/java/com/edgedb/driver/binary/PacketSerializer.java#L77-L98

although, this code failed to account for successful contracts with *remaining* data, ignoring it and misreading the protocol data.

This PR fixes that by correctly consuming the remaining data of a completed contract, as well as correctly handling cases where multiple chunks are sent for one large data message.