### PR TITLE
Documentation: Adds missing Maven dependency version

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -35,6 +35,7 @@ project.
         <dependency>
             <groupId>com.edgedb</groupId>
             <artifactId>driver</artifactId>
+            <version>0.2.1</version>
         </dependency>
 
     .. code-tab:: groovy


### PR DESCRIPTION
Currently, the version information for the Maven dependency is missing within the EdgeDB documentation: https://www.edgedb.com/docs/clients/java/index

This PR adds the missing version information to fix the related Maven error:
```
[...]
[ERROR] [ERROR] Some problems were encountered while processing the POMs:
[ERROR] 'dependencies.dependency.version' for com.edgedb:driver:jar is missing. @ line 23, column 14
[...]
```