### PR TITLE
Fix transaction deadlock in client pool

### DIFF
--- a/src/driver/src/main/java/com/edgedb/driver/EdgeDBClient.java
+++ b/src/driver/src/main/java/com/edgedb/driver/EdgeDBClient.java
@@ -28,6 +28,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
+import static com.edgedb.driver.util.ComposableUtil.composeWith;
+
 /**
  * Represents a client pool used to interact with EdgeDB.
  */
@@ -169,7 +171,7 @@ public final class EdgeDBClient implements StatefulClient, EdgeDBQueryable, Auto
      * @param <T> The result of the query.
      */
     public <T> CompletionStage<T> transaction(@NotNull Function<Transaction, CompletionStage<T>> func) {
-        return getTransactableClient().thenCompose(client -> client.transaction(func));
+        return composeWith(getTransactableClient(), client -> client.transaction(func));
     }
 
     /**

--- a/src/driver/src/main/java/com/edgedb/driver/EdgeDBClient.java
+++ b/src/driver/src/main/java/com/edgedb/driver/EdgeDBClient.java
@@ -160,7 +160,7 @@ public final class EdgeDBClient implements StatefulClient, EdgeDBQueryable, Auto
             TransactionSettings settings,
             @NotNull Function<Transaction, CompletionStage<T>> func
     ) {
-        return getTransactableClient().thenCompose(client -> client.transaction(settings, func));
+        return composeWith(getTransactableClient(), client -> client.transaction(settings, func));
     }
 
     /**

--- a/src/driver/src/main/java/com/edgedb/driver/clients/TransactableClient.java
+++ b/src/driver/src/main/java/com/edgedb/driver/clients/TransactableClient.java
@@ -7,7 +7,7 @@ import org.jetbrains.annotations.NotNull;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
 
-public interface TransactableClient extends EdgeDBQueryable {
+public interface TransactableClient extends EdgeDBQueryable, AutoCloseable {
     TransactionState getTransactionState();
 
     default <T> CompletionStage<T> transaction(@NotNull Function<Transaction, CompletionStage<T>> func) {


### PR DESCRIPTION
## Summary
When running a transaction with the `transaction()` method on `EdgeDBClient`, a client is fetched or created from the underlying client pool. The client from the pool is used to run the entire transaction block, the issue is that the binding didn't return the client back to the pool after use. 

This PR fixes this by explicitly calling the `close` method on the client after the transaction block completes (successfully or not) via the `composeWith` method.

Fixes #21 