### PR TITLE
Fix reconnection deadlock

### DIFF
--- a/src/driver/src/main/java/com/edgedb/driver/async/ChannelCompletableFuture.java
+++ b/src/driver/src/main/java/com/edgedb/driver/async/ChannelCompletableFuture.java
@@ -2,23 +2,32 @@ package com.edgedb.driver.async;
 
 import io.netty.channel.ChannelFuture;
 import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.CompletableFuture;
 
 public class ChannelCompletableFuture extends CompletableFuture<Void> {
+    private static final Logger logger = LoggerFactory.getLogger(ChannelCompletableFuture.class);
+
     public static @NotNull ChannelCompletableFuture completeFrom(@NotNull ChannelFuture future) {
         var completableFuture = new ChannelCompletableFuture();
+        logger.debug("Registering {}", future.hashCode());
 
         future.addListener((v) -> {
             if(v.cause() != null) {
+                logger.debug("Failing from {}", future.hashCode());
                 completableFuture.completeExceptionally(v.cause());
                 return;
             }
 
             if(v.isCancelled()) {
+                logger.debug("Cancelling from {}", future.hashCode());
                 completableFuture.cancel(true);
                 return;
             }
+
+            logger.debug("Completing from {}", future.hashCode());
 
             completableFuture.complete(null);
         });

--- a/src/driver/src/main/java/com/edgedb/driver/clients/BaseEdgeDBClient.java
+++ b/src/driver/src/main/java/com/edgedb/driver/clients/BaseEdgeDBClient.java
@@ -7,6 +7,8 @@ import com.edgedb.driver.async.AsyncEvent;
 import com.edgedb.driver.state.Config;
 import com.edgedb.driver.state.Session;
 import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Map;
 import java.util.Optional;
@@ -15,6 +17,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 
 public abstract class BaseEdgeDBClient implements StatefulClient, EdgeDBQueryable, AutoCloseable {
+    private static final Logger logger = LoggerFactory.getLogger(BaseEdgeDBClient.class);
     private final @NotNull AsyncEvent<BaseEdgeDBClient> onReady;
     private final EdgeDBConnection connection;
     private final EdgeDBClientConfig config;
@@ -89,7 +92,10 @@ public abstract class BaseEdgeDBClient implements StatefulClient, EdgeDBQueryabl
     public abstract CompletionStage<Void> disconnect();
 
     public CompletionStage<Void> reconnect() {
-        return disconnect().thenCompose((v) -> connect());
+        return disconnect().thenCompose((v) -> {
+            logger.debug("Executing connection attempt from reconnect");
+            return connect();
+        });
     }
 
     @Override


### PR DESCRIPTION
## Summary
When the binding idles for 2 ish minutes, the server sends an `IDLE_SESSION_TIMEOUT_ERROR` error indicating that the binding should disconnect until another query is ready to be run.

The bindings logic would reset the state of the connection and only attempt to reconnect on a query call, the issue lies with the implementation of this logic with Netty. When the client resets the promises for indicating both when the client is connected as well as the ready state (when the binding receives `READY_FOR_COMMAND` message). The issue lies with the connection ready state, since our code looks like the following psuedo-code:
```java
public CompletionStage<Void> send(Sendable message) {
  return whenConnectionReady()
    .thenCompose(v -> {
      if(!this.isConnected) {
        return reconnect().thenCompose(v -> send0(message));
      }
      return send0(message);
    });
}
```
we rely on the connection ready event to preform reconnect logic, the reason for this is the following states:
- If we're already starting a connection and queue up the client handshake to be sent, the send method should wait for that connection to succeed or fail before trying to send a message
- If we're already connected this completion state is successful allowing the binding to send the message right away.

During reconnect logic, if the binding detected a disconnect it would call the client `connect` method, which is responsible for resetting the connection state which includes both promises, the way it would reset the connection promise is by triggering a custom Netty pipeline event that resets the promise:
```java
@Override
public void userEventTriggered(ChannelHandlerContext ctx, @NotNull Object evt) {
  if(evt.equals("RESET")) {
    // resets the promise
  }

  ...
}
```

The issue was that this pipeline event wasn't triggered synchronously with the connection reset code, so ultimately it would keep the old promise (which has been completed) and follow the reconnect cycle again which is controlled by a lock, causing a deadlock.

This PR fixes that by making the reset promise synchronous within the pipeline by making the callee run the reset instead of the netty pipeline thread.
