### PR TITLE
Fix multi-link deserialization

### DIFF
--- a/dbschema/migrations/00008.edgeql
+++ b/dbschema/migrations/00008.edgeql
@@ -1,0 +1,9 @@
+CREATE MIGRATION m1xt33ahn2zm5wiwbdubmpttdcg5ywahjme2dnpj3jx3hfhkzcc3sq
+    ONTO m1tig3qk3mnrb2xpszwyodgurkdeyza6yt67zo7kfljc2icy3e7yma
+{
+  CREATE TYPE tests::Links {
+      CREATE LINK b: tests::Links;
+      CREATE MULTI LINK c: tests::Links;
+      CREATE PROPERTY a: std::str;
+  };
+};

--- a/dbschema/migrations/00009.edgeql
+++ b/dbschema/migrations/00009.edgeql
@@ -1,0 +1,9 @@
+CREATE MIGRATION m1hds33s7w5uj53nhqljjf7cqpzzv64csyo7r4di4cf5f22q5ydywa
+    ONTO m1xt33ahn2zm5wiwbdubmpttdcg5ywahjme2dnpj3jx3hfhkzcc3sq
+{
+  ALTER TYPE tests::Links {
+      ALTER PROPERTY a {
+          CREATE CONSTRAINT std::exclusive;
+      };
+  };
+};

--- a/dbschema/tests.esdl
+++ b/dbschema/tests.esdl
@@ -4,4 +4,12 @@ module tests {
         required property b -> str;
         required property c -> str;
     }
+
+    type Links {
+        a: str {
+            constraint exclusive;
+        };
+        b: Links;
+        multi c: Links;
+    }
 }

--- a/examples/java-examples/src/main/java/com/edgedb/examples/LinkProperties.java
+++ b/examples/java-examples/src/main/java/com/edgedb/examples/LinkProperties.java
@@ -1,6 +1,7 @@
 package com.edgedb.examples;
 
 import com.edgedb.driver.EdgeDBClient;
+import com.edgedb.driver.annotations.EdgeDBLinkType;
 import com.edgedb.driver.annotations.EdgeDBType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -16,6 +17,7 @@ public final class LinkProperties implements Example {
         public String name;
         public Long age;
         public Person bestFriend;
+        @EdgeDBLinkType(Person.class)
         public Collection<Person> friends;
     }
 

--- a/src/driver/src/main/java/com/edgedb/driver/binary/codecs/visitors/TypeVisitor.java
+++ b/src/driver/src/main/java/com/edgedb/driver/binary/codecs/visitors/TypeVisitor.java
@@ -131,6 +131,10 @@ public final class TypeVisitor implements CodecVisitor {
         // context type control:
         // inner codec:
         try(var ignored = visitor.enterNewContext(v -> {
+            if(v.isRealType) {
+                return;
+            }
+
             var innerType = TypeUtils.tryPullWrappingType(visitor.getContext().type);
 
             if(innerType == null) {


### PR DESCRIPTION
## Summary
This PR fixes multi-link deserialization by ensuring that `EdgeDBLinkType` annotation is actually used within codec visitors