### PR TITLE
Fix custom deserializer annotations being ignored

### DIFF
--- a/examples/scala-examples/build.sbt
+++ b/examples/scala-examples/build.sbt
@@ -3,7 +3,7 @@ ThisBuild / version := "0.1.0-SNAPSHOT"
 ThisBuild / scalaVersion := "3.1.3"
 
 libraryDependencies ++= Seq(
-  "com.edgedb" % "driver" % "0.2.3" from "file:///" + System.getProperty("user.dir") + "/lib/com.edgedb.driver-0.2.3.jar",
+  "com.edgedb" % "driver" % "0.2.4" from "file:///" + System.getProperty("user.dir") + "/lib/com.edgedb.driver-0.2.4-SNAPSHOT.jar",
   "ch.qos.logback" % "logback-classic" % "1.4.7",
   "ch.qos.logback" % "logback-core" % "1.4.7",
   "com.fasterxml.jackson.core" % "jackson-databind" % "2.15.1",

--- a/src/driver/src/test/java/CustomDeserializerTests.java
+++ b/src/driver/src/test/java/CustomDeserializerTests.java
@@ -1,0 +1,53 @@
+import com.edgedb.driver.EdgeDBClient;
+import com.edgedb.driver.annotations.EdgeDBDeserializer;
+import com.edgedb.driver.annotations.EdgeDBLinkType;
+import com.edgedb.driver.annotations.EdgeDBName;
+import com.edgedb.driver.annotations.EdgeDBType;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CustomDeserializerTests {
+
+    @EdgeDBType
+    public static final class Links {
+        private String namesHereAreIrrelevant;
+        private Links sinceTheCustomDeserializer;
+        private Collection<Links> shouldMapNames;
+
+        @EdgeDBDeserializer
+        public Links(
+                @EdgeDBName("a") String a,
+                @EdgeDBName("b") Links b,
+                @EdgeDBName("c") @EdgeDBLinkType(Links.class) Collection<Links> c
+        ) {
+            this.namesHereAreIrrelevant = a;
+            this.sinceTheCustomDeserializer = b;
+            this.shouldMapNames = c;
+        }
+    }
+
+    @Test
+    public void testCustomDeserializerParameterAnnotations() throws Exception {
+        try(var client = new EdgeDBClient().withModule("tests")) {
+            var result = client.queryRequiredSingle(
+                    Links.class,
+                    "with test1 := (insert Links { a := '123' } unless conflict on .a else (select Links))," +
+                    "test2 := (insert Links { a := '456', b := test1 } unless conflict on .a else (select Links))," +
+                    "test3 := (insert Links { a := '789', b := test2, c := { test1, test2 }} unless conflict on .a else (select Links)) " +
+                    "select test3 {a, b: {a, b, c }, c: {a, b, c}}"
+            ).toCompletableFuture().get();
+
+            assertThat(result.namesHereAreIrrelevant).isEqualTo("789");
+            assertThat(result.shouldMapNames.size()).isEqualTo(2);
+
+            for(var link : result.shouldMapNames) {
+                assertThat(link.getClass()).isEqualTo(Links.class);
+            }
+
+            assertThat(result.sinceTheCustomDeserializer).isNotNull();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
This PR fixes an issue where custom deserializer annotations (like `@EdgeDBLinkType`) are ignored. The way this is fixed is to promote these annotations to field-level, interop-ing with existing deserialization logic.