### PR TITLE
Don't parse if no args and result

### DIFF
--- a/src/driver/src/main/java/com/edgedb/driver/binary/builders/CodecBuilder.java
+++ b/src/driver/src/main/java/com/edgedb/driver/binary/builders/CodecBuilder.java
@@ -54,6 +54,8 @@ public final class CodecBuilder {
     public static final UUID NULL_CODEC_ID = new UUID(0L, 0L);
     public static final UUID INVALID_CODEC_ID = new UUID(Long.MAX_VALUE, Long.MAX_VALUE);
 
+    public static final NullCodec NULL_CODEC = new NullCodec();
+
     private static final ConcurrentMap<ProtocolVersion, CodecCache> codecCaches;
 
     static {

--- a/src/driver/src/main/java/com/edgedb/driver/clients/EdgeDBTCPClient.java
+++ b/src/driver/src/main/java/com/edgedb/driver/clients/EdgeDBTCPClient.java
@@ -135,7 +135,6 @@ public class EdgeDBTCPClient extends EdgeDBBinaryClient implements TransactableC
 
     @Override
     public CompletionStage<Void> startTransaction(@NotNull TransactionIsolation isolation, boolean readonly, boolean deferrable) {
-
         String query = "start transaction isolation " +
                 isolation +
                 ", " +


### PR DESCRIPTION
## Summary

This PR removes a round trip parse call in the case that there is no query arguments and output

Complies with https://github.com/edgedb/edgedb/pull/6576