### PR TITLE
Newer netty version without vulnerabilities

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ ext {
     // dependencies
     jackson_version = '2.15.2'
     slf4j_version = '2.0.5'
-    netty_version = '4.1.89.Final'
+    netty_version = '4.1.109.Final'
     joou_version = '0.9.4'
     reflections_version = '0.10.2'
 


### PR DESCRIPTION
Netty 4.1.89.Final has several vulnerabilities which have been patched https://mvnrepository.com/artifact/io.netty/netty-handler/4.1.89.Final