### PR TITLE
Fix optional argument encoding

### DIFF
--- a/examples/java-examples/src/main/java/com/edgedb/examples/AbstractTypes.java
+++ b/examples/java-examples/src/main/java/com/edgedb/examples/AbstractTypes.java
@@ -28,19 +28,25 @@ public class AbstractTypes implements Example {
     @Override
     public CompletionStage<Void> run(EdgeDBClient client) {
         return client
-                .execute("insert Movie { title := \"The Matrix\", release_year := 1999 } unless conflict on .title")
-                .thenCompose(v -> client.execute("insert Show { title := \"The Office\", seasons := 9 } unless conflict on .title"))
-                .thenCompose(v -> client.query(Media.class, "select Media { title, [is Movie].release_year, [is Show].seasons }"))
+                .querySingle(String.class, "select <optional str>$arg")
                 .thenAccept(content -> {
-                    for (var media : content) {
-                        if(media instanceof Show) {
-                            logger.info("Got show {}", media);
-                        }
-
-                        if(media instanceof Movie) {
-                            logger.info("Got movie {}", media);
-                        }
-                    }
+                    logger.info("Content: {}", content);
                 });
+
+//        return client
+//                .execute("insert Movie { title := \"The Matrix\", release_year := 1999 } unless conflict on .title")
+//                .thenCompose(v -> client.execute("insert Show { title := \"The Office\", seasons := 9 } unless conflict on .title"))
+//                .thenCompose(v -> client.query(Media.class, "select Media { title, [is Movie].release_year, [is Show].seasons }"))
+//                .thenAccept(content -> {
+//                    for (var media : content) {
+//                        if(media instanceof Show) {
+//                            logger.info("Got show {}", media);
+//                        }
+//
+//                        if(media instanceof Movie) {
+//                            logger.info("Got movie {}", media);
+//                        }
+//                    }
+//                });
     }
 }


### PR DESCRIPTION
## Summary
Fixes encoding of arguments by ensuring [`nelems`](https://docs.edgedb.com/database/reference/protocol/dataformats#tuple-namedtuple-and-object) is set to the absolute number of elements, and client-side checks whether the argument is optional.